### PR TITLE
Add FileGameLogger and logDir option

### DIFF
--- a/forge-gui-desktop/src/main/java/forge/view/FileGameLogger.java
+++ b/forge-gui-desktop/src/main/java/forge/view/FileGameLogger.java
@@ -2,8 +2,12 @@ package forge.view;
 
 import com.google.common.eventbus.Subscribe;
 import forge.ai.GameState;
+import forge.game.Game;
 import forge.game.GameLogEntry;
+import forge.game.GameOutcome;
 import forge.game.event.GameEventTurnPhase;
+import forge.game.player.Player;
+import forge.game.player.RegisteredPlayer;
 import forge.item.IPaperCard;
 import forge.model.FModel;
 
@@ -20,9 +24,24 @@ import java.util.Observer;
  */
 public class FileGameLogger implements Observer, Closeable {
     private final BufferedWriter writer;
+    private final Game game;
 
-    public FileGameLogger(File file) throws IOException {
+    public FileGameLogger(File file, Game game) throws IOException {
         this.writer = new BufferedWriter(new FileWriter(file, true));
+        this.game = game;
+        writePlayers();
+    }
+
+    private void writePlayers() throws IOException {
+        writer.write("=== Players ===");
+        writer.newLine();
+        for (Player p : game.getRegisteredPlayers()) {
+            RegisteredPlayer rp = p.getRegisteredPlayer();
+            writer.write(p.getName() + " - " + rp.getDeck().getName());
+            writer.newLine();
+        }
+        writer.newLine();
+        writer.flush();
     }
 
     @Override
@@ -52,6 +71,24 @@ public class FileGameLogger implements Observer, Closeable {
             writer.newLine();
             writer.flush();
         } catch (Exception e) {
+            // ignore logging failures
+        }
+    }
+
+    public void logWinner(Game g) {
+        try {
+            writer.write("=== Winner ===");
+            writer.newLine();
+            GameOutcome outcome = g.getOutcome();
+            if (outcome.isDraw()) {
+                writer.write("Game ended in a draw");
+            } else {
+                RegisteredPlayer rp = outcome.getWinningPlayer();
+                writer.write(rp.getPlayer().getName() + " with deck " + rp.getDeck().getName());
+            }
+            writer.newLine();
+            writer.flush();
+        } catch (IOException e) {
             // ignore logging failures
         }
     }

--- a/forge-gui-desktop/src/main/java/forge/view/FileGameLogger.java
+++ b/forge-gui-desktop/src/main/java/forge/view/FileGameLogger.java
@@ -1,0 +1,63 @@
+package forge.view;
+
+import com.google.common.eventbus.Subscribe;
+import forge.ai.GameState;
+import forge.game.GameLogEntry;
+import forge.game.event.GameEventTurnPhase;
+import forge.item.IPaperCard;
+import forge.model.FModel;
+
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Observable;
+import java.util.Observer;
+
+/**
+ * Logs game events and states to a file.
+ */
+public class FileGameLogger implements Observer, Closeable {
+    private final BufferedWriter writer;
+
+    public FileGameLogger(File file) throws IOException {
+        this.writer = new BufferedWriter(new FileWriter(file, true));
+    }
+
+    @Override
+    public void update(Observable o, Object arg) {
+        if (arg instanceof GameLogEntry) {
+            try {
+                writer.write(((GameLogEntry) arg).toString());
+                writer.newLine();
+                writer.flush();
+            } catch (IOException e) {
+                // ignore logging failures
+            }
+        }
+    }
+
+    @Subscribe
+    public void onTurnPhase(GameEventTurnPhase event) {
+        GameState state = new GameState() {
+            @Override
+            public IPaperCard getPaperCard(String cardName, String setCode, int artID) {
+                return FModel.getMagicDb().getCommonCards().getCard(cardName, setCode, artID);
+            }
+        };
+        try {
+            state.initFromGame(event.playerTurn.getGame());
+            writer.write(state.toString());
+            writer.newLine();
+            writer.flush();
+        } catch (Exception e) {
+            // ignore logging failures
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        writer.close();
+    }
+}

--- a/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
+++ b/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
@@ -19,6 +19,7 @@ import forge.game.GameRules;
 import forge.game.GameType;
 import forge.game.Match;
 import forge.game.player.RegisteredPlayer;
+import forge.view.FileGameLogger;
 import forge.gamemodes.tournament.system.AbstractTournament;
 import forge.gamemodes.tournament.system.TournamentBracket;
 import forge.gamemodes.tournament.system.TournamentPairing;
@@ -184,7 +185,7 @@ public class SimulateMatch {
         if (logDir != null) {
             File logFile = new File(logDir, "game_" + iGame + ".log");
             try {
-                logger = new FileGameLogger(logFile);
+                logger = new FileGameLogger(logFile, g1);
                 g1.subscribeToEvents(logger);
                 g1.getGameLog().addObserver(logger);
             } catch (IOException e) {
@@ -210,6 +211,7 @@ public class SimulateMatch {
             }
             if (logger != null) {
                 try {
+                    logger.logWinner(g1);
                     logger.close();
                 } catch (IOException e) {
                     System.err.println("Failed to close logger: " + e.getMessage());

--- a/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
+++ b/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
@@ -58,7 +58,8 @@ public class SimulateMatch {
                 }
 
                 options = new ArrayList<>();
-                params.put(a.substring(1), options);
+                final String key = a.startsWith("--") ? a.substring(2) : a.substring(1);
+                params.put(key, options);
             } else if (options != null) {
                 options.add(a);
             } else {
@@ -80,6 +81,13 @@ public class SimulateMatch {
         }
 
         boolean outputGamelog = !params.containsKey("q");
+        File logDir = null;
+        if (params.containsKey("logDir")) {
+            logDir = new File(params.get("logDir").get(0));
+            if (!logDir.exists()) {
+                logDir.mkdirs();
+            }
+        }
 
         GameType type = GameType.Constructed;
         if (params.containsKey("f")) {
@@ -94,7 +102,7 @@ public class SimulateMatch {
         }
 
         if (params.containsKey("t")) {
-            simulateTournament(params, rules, outputGamelog);
+            simulateTournament(params, rules, outputGamelog, logDir);
             System.out.flush();
             return;
         }
@@ -140,12 +148,12 @@ public class SimulateMatch {
             int iGame = 0;
             while (!mc.isMatchOver()) {
                 // play games until the match ends
-                simulateSingleMatch(mc, iGame, outputGamelog);
+                simulateSingleMatch(mc, iGame, outputGamelog, logDir);
                 iGame++;
             }
         } else {
             for (int iGame = 0; iGame < nGames; iGame++) {
-                simulateSingleMatch(mc, iGame, outputGamelog);
+                simulateSingleMatch(mc, iGame, outputGamelog, logDir);
             }
         }
 
@@ -163,14 +171,26 @@ public class SimulateMatch {
         System.out.println("\tT - Type of tournament to run with all provided decks (Bracket, RoundRobin, Swiss)");
         System.out.println("\tP - Amount of players per match (used only with Tournaments, defaults to 2)");
         System.out.println("\tF - format of games, defaults to constructed");
+        System.out.println("\t--logDir - directory to output structured game logs");
         System.out.println("\tq - Quiet flag. Output just the game result, not the entire game log.");
     }
 
-    public static void simulateSingleMatch(final Match mc, int iGame, boolean outputGamelog) {
+    public static void simulateSingleMatch(final Match mc, int iGame, boolean outputGamelog, File logDir) {
         final StopWatch sw = new StopWatch();
         sw.start();
 
         final Game g1 = mc.createGame();
+        FileGameLogger logger = null;
+        if (logDir != null) {
+            File logFile = new File(logDir, "game_" + iGame + ".log");
+            try {
+                logger = new FileGameLogger(logFile);
+                g1.subscribeToEvents(logger);
+                g1.getGameLog().addObserver(logger);
+            } catch (IOException e) {
+                System.err.println("Failed to initialize logger: " + e.getMessage());
+            }
+        }
         // will run match in the same thread
         try {
             TimeLimitedCodeBlock.runWithTimeout(() -> {
@@ -187,6 +207,13 @@ public class SimulateMatch {
             }
             if (!g1.isGameOver()) {
                 g1.setGameOver(GameEndReason.Draw);
+            }
+            if (logger != null) {
+                try {
+                    logger.close();
+                } catch (IOException e) {
+                    System.err.println("Failed to close logger: " + e.getMessage());
+                }
             }
         }
 
@@ -209,7 +236,7 @@ public class SimulateMatch {
         }
     }
 
-    private static void simulateTournament(Map<String, List<String>> params, GameRules rules, boolean outputGamelog) {
+    private static void simulateTournament(Map<String, List<String>> params, GameRules rules, boolean outputGamelog, File logDir) {
         String tournament = params.get("t").get(0);
         AbstractTournament tourney = null;
         int matchPlayers = params.containsKey("p") ? Integer.parseInt(params.get("p").get(0)) : 2;
@@ -306,7 +333,7 @@ public class SimulateMatch {
                 while (!mc.isMatchOver()) {
                     // play games until the match ends
                     try {
-                        simulateSingleMatch(mc, iGame, outputGamelog);
+                        simulateSingleMatch(mc, iGame, outputGamelog, logDir);
                         iGame++;
                     } catch (Exception e) {
                         exceptions++;

--- a/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
+++ b/forge-gui-desktop/src/main/java/forge/view/SimulateMatch.java
@@ -1,6 +1,7 @@
 package forge.view;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;

--- a/forge-gui-desktop/src/test/java/forge/planarconquestgenerate/PlanarConquestGeneraterGA.java
+++ b/forge-gui-desktop/src/test/java/forge/planarconquestgenerate/PlanarConquestGeneraterGA.java
@@ -241,7 +241,7 @@ public class PlanarConquestGeneraterGA extends AbstractGeneticAlgorithm<Deck> {
                 while (!mc.isMatchOver()) {
                     // play games until the match ends
                     try{
-                        SimulateMatch.simulateSingleMatch(mc, iGame, false);
+                        SimulateMatch.simulateSingleMatch(mc, iGame, false, null);
                         iGame++;
                     } catch(Exception e) {
                         exceptions++;


### PR DESCRIPTION
## Summary
- implement `FileGameLogger` to dump game logs and board states
- add `--logDir` option to `SimulateMatch` and wire up logger usage
- update tests and docs

## Testing
- `mvn -q -DskipTests install` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a792cf5c0832897214e725785d50b